### PR TITLE
Fix distance display on nearest page

### DIFF
--- a/app/Http/Controllers/NearestAlgorithmController.php
+++ b/app/Http/Controllers/NearestAlgorithmController.php
@@ -45,11 +45,12 @@ class NearestAlgorithmController extends Controller
         ->whereNotNull('longitude')
         ->get()
         ->map(function ($college) use ($userLat, $userLon) {
-            // Ensure latitude and longitude are numbers
             $collegeLat = floatval($college->latitude);
             $collegeLon = floatval($college->longitude);
 
-            $college->distance = $this->haversineDistance($userLat, $userLon, $collegeLat, $collegeLon);
+            // Calculate distance in kilometers and convert to meters for display consistency
+            $distanceKm = $this->haversineDistance($userLat, $userLon, $collegeLat, $collegeLon);
+            $college->distance = $distanceKm * 1000; // meters
 
             return $college;
         })

--- a/resources/views/home/nearest.blade.php
+++ b/resources/views/home/nearest.blade.php
@@ -83,8 +83,10 @@
                     
                     @if(property_exists($college, 'distance'))
                         @php
-                            $distance = $college->distance;
-                            $distanceFormatted = $distance >= 1 ? number_format($distance, 2).' km' : number_format($distance*1000,0).' m';
+                            $distanceMeters = (float) $college->distance;
+                            $distanceFormatted = $distanceMeters >= 1000
+                                ? number_format($distanceMeters / 1000, 2) . ' km'
+                                : number_format($distanceMeters, 0) . ' m';
                         @endphp
                         <div class="card-text mt-2"><strong>{{ $distanceFormatted }}</strong></div>
                     @endif


### PR DESCRIPTION
Corrects distance unit display on the nearest colleges page by standardizing backend distance to meters and refining frontend formatting.

Previously, the `nearest.blade.php` view incorrectly displayed distances, often showing meters as kilometers, due to inconsistent unit handling. This PR standardizes distance values to meters in the `NearestAlgorithmController` and updates the view to correctly format these values as 'm' or 'km' based on their magnitude.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ecd5ee7-1b76-46f8-86a1-0dd3bb2ae5b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0ecd5ee7-1b76-46f8-86a1-0dd3bb2ae5b2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

